### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/get_new_flowers.py
+++ b/get_new_flowers.py
@@ -517,7 +517,7 @@ def is_valid_github_url(url):
         # Check hostname is github.com
         if not parsed.hostname:
             return False
-        if not parsed.hostname.endswith('github.com'):
+        if not (parsed.hostname == 'github.com' or parsed.hostname.endswith('.github.com')):
             return False
             
         # Validate path exists and has expected format

--- a/get_new_flowers.py
+++ b/get_new_flowers.py
@@ -517,7 +517,7 @@ def is_valid_github_url(url):
         # Check hostname is github.com
         if not parsed.hostname:
             return False
-        if not (parsed.hostname == 'github.com' or parsed.hostname.endswith('.github.com')):
+        if not (parsed.hostname == 'github.com' or parsed.hostname.endswith('.github.com')): # Ensure hostname is github.com or a valid subdomain
             return False
             
         # Validate path exists and has expected format


### PR DESCRIPTION
Potential fix for [https://github.com/TheRealFREDP3D/Gemini-Code-Assist-PR-Poetry/security/code-scanning/2](https://github.com/TheRealFREDP3D/Gemini-Code-Assist-PR-Poetry/security/code-scanning/2)

To fix the issue, we need to ensure that the hostname is either `github.com` or a valid subdomain of `github.com`. This can be achieved by checking if the hostname equals `github.com` or ends with `.github.com` (with a preceding dot to avoid matching invalid hostnames like `malicious-github.com`). This approach ensures that only legitimate GitHub domains are accepted.

The changes will be made in the `is_valid_github_url` function, specifically in the hostname validation logic. We will replace the `endswith('github.com')` check with a stricter validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Strengthen hostname validation in is_valid_github_url to only allow github.com and its subdomains.